### PR TITLE
Exam News API Enhancements, Silos Field Handling and Data Consistency, College Info URL Mapping Fixes,  Miscellaneous changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "kollege-apply",
-  "version": "0.0.1",
+  "name": "truescholar",
+  "version": "0.1.1",
   "description": "",
   "author": "",
   "private": true,

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -43,6 +43,6 @@ export class AppService implements OnModuleInit {
   }
 
   getHello(): string {
-    return "Hello From truescholar! - 13-08-2025 6:11 pm";
+    return "Hello From truescholar! - 14-08-2025 9:52 pm";
   }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -43,6 +43,6 @@ export class AppService implements OnModuleInit {
   }
 
   getHello(): string {
-    return "Hello From Kollegeapply! - 13-08-2025 6:11 pm";
+    return "Hello From truescholar! - 13-08-2025 6:11 pm";
   }
 }

--- a/src/articles_modules/author/author.service.ts
+++ b/src/articles_modules/author/author.service.ts
@@ -145,7 +145,7 @@ export class AuthorService {
     if (type === "colleges") {
       const [collegeContent, total] = await this.collegeContentRepository
         .createQueryBuilder("collegeContent")
-        .leftJoinAndSelect("collegeContent.college", "college")
+        .leftJoinAndSelect("collegeContent.college", "college_info")
         .where("collegeContent.author_id = :authorId", { authorId })
         .select([
           "collegeContent.updated_at",
@@ -153,9 +153,10 @@ export class AuthorService {
           "collegeContent.college_content_id",
           "collegeContent.meta_desc",
           "collegeContent.title",
-          "college.college_id",
-          "college.college_name",
-          "college.slug",
+          "college_info.college_id",
+          "college_info.college_name",
+          "college_info.slug",
+          "collegeContent.silos",
         ])
         .orderBy("collegeContent.updated_at", "DESC")
         .skip(offset)
@@ -173,6 +174,7 @@ export class AuthorService {
         slug: item.college?.slug,
         entity_id: item.college?.college_id,
         entity_name: item.college?.college_name,
+        silos: item.silos,
       }));
 
       return {
@@ -200,6 +202,7 @@ export class AuthorService {
           "exam.exam_name",
           "exam.slug",
           "exam.exam_id",
+          "examContent.silos",
         ])
         .orderBy("examContent.updated_at", "DESC")
         .skip(offset)
@@ -217,6 +220,7 @@ export class AuthorService {
         slug: item.exam?.exam_name,
         entity_id: item.exam?.exam_id,
         entity_name: item.exam?.exam_name,
+        silos: item.silos,
       }));
 
       return {

--- a/src/college/college-info/college-info.service.ts
+++ b/src/college/college-info/college-info.service.ts
@@ -1914,7 +1914,7 @@ export class CollegeInfoService {
           ...dynamicFields,
         },
         news_section: news,
-        highlight_section: [groupContentsBySilos("highlights")[0] || null],
+        highlight_section: [groupContentsBySilos("highlight")[0] || null],
         exam_section: examSection,
       };
 
@@ -2148,17 +2148,20 @@ export class CollegeInfoService {
     const baseUrl = `https://www.kollegeapply.com/colleges/${slug}`;
     const silosMapping = {
       info: `${baseUrl}`,
-      highlights: `${baseUrl}/highlights`,
+      highlight: `${baseUrl}/highlights`,
       courses: `${baseUrl}/courses`,
       fees: `${baseUrl}/fees`,
       admission: `${baseUrl}/admission-process`,
-      cutoff: `${baseUrl}/cutoff`,
-      placement: `${baseUrl}/placement`,
-      ranking: `${baseUrl}/ranking`,
+      cutoff: `${baseUrl}/cutoffs`,
+      placement: `${baseUrl}/placements`,
+      ranking: `${baseUrl}/rankings`,
       scholarship: `${baseUrl}/scholarship`,
-      facilities: `${baseUrl}/facilities`,
+      facility: `${baseUrl}/facilities`,
       faq: `${baseUrl}/faq`,
       news: `${baseUrl}/news`,
+      other: `${baseUrl}/others`,
+      result: `${baseUrl}/results`,
+      eligibility: `${baseUrl}/eligibility`,
     };
 
     // Initialize all fields as false

--- a/src/exams_module/exams/exams.controller.ts
+++ b/src/exams_module/exams/exams.controller.ts
@@ -177,4 +177,26 @@ export class ExamsController {
   async getExamsByStream(@Param("streamId") streamId: number): Promise<any[]> {
     return this.examsService.findExamsByStream(streamId);
   }
+
+  @Get("/news/:id")
+  @ApiOperation({ summary: "Get all news for a specific exam" })
+  @ApiResponse({
+    status: 200,
+    description: "List of news articles for the exam.",
+  })
+  @ApiResponse({ status: 404, description: "Exam not found." })
+  async getExamNews(@Param("id") id: number): Promise<any> {
+    return this.examsService.getExamNews(id);
+  }
+
+  @Get("/news/individual/:newsId")
+  @ApiOperation({ summary: "Get individual news by news ID" })
+  @ApiResponse({
+    status: 200,
+    description: "Individual news article details.",
+  })
+  @ApiResponse({ status: 404, description: "News not found." })
+  async getExamNewsByNewsId(@Param("newsId") newsId: number): Promise<any> {
+    return this.examsService.getExamNewsByNewsId(newsId);
+  }
 }


### PR DESCRIPTION
This pull request introduces several updates across the codebase, including a rebranding of the application, enhancements to the handling of "silos" fields, improvements to how exam news is managed and exposed via new endpoints, and fixes to URL mappings for college information sections. The changes improve data consistency, expand API functionality, and align the project with the new brand identity.

**Branding and Naming Updates**
* Renamed the project in `package.json` from `kollege-apply` to `truescholar`, and updated the version number.
* Updated the greeting string in the `AppService.getHello()` method to reference `truescholar`.

**Exam News API Enhancements**
* Added two new endpoints in `ExamsController`: one to fetch all news for a specific exam, and another to fetch individual news articles by news ID.
* Implemented corresponding service methods in `ExamsService` to support these endpoints, including data transformation and error handling.

**Silos Field Handling and Data Consistency**
* Updated queries and returned data in `AuthorService` to include the `silos` field for both college and exam content, improving the granularity of returned entities. [[1]](diffhunk://#diff-eb53bfdf3838fa68f29b8e577b3fb9b80585395f15bdaef7e5d1f9f4205c6511L148-R159) [[2]](diffhunk://#diff-eb53bfdf3838fa68f29b8e577b3fb9b80585395f15bdaef7e5d1f9f4205c6511R177) [[3]](diffhunk://#diff-eb53bfdf3838fa68f29b8e577b3fb9b80585395f15bdaef7e5d1f9f4205c6511R205) [[4]](diffhunk://#diff-eb53bfdf3838fa68f29b8e577b3fb9b80585395f15bdaef7e5d1f9f4205c6511R223)
* Fixed a typo in the grouping logic for highlights in `CollegeInfoService`, changing `"highlights"` to `"highlight"` for consistency.

**College Info URL Mapping Fixes**
* Corrected and expanded the `silosMapping` object in `CollegeInfoService` to ensure URLs match updated silos names (e.g., `highlight`, `cutoffs`, `placements`, `rankings`, `facility`, `others`, `results`, `eligibility`).

**Exam Question Papers Logic**
* Reactivated logic to check for the existence of question papers in `ExamsService`, and included `question_papers` in the `distinctSilos` array when present. [[1]](diffhunk://#diff-67290b3802a69c9fa780e357eef9b16dfbaa8c166c2d84ab0d0937d70dfc0a6dL270-R273) [[2]](diffhunk://#diff-67290b3802a69c9fa780e357eef9b16dfbaa8c166c2d84ab0d0937d70dfc0a6dL291-R296)